### PR TITLE
GetSpellBookItemName now used to iterate over spellbook

### DIFF
--- a/SmartBuff.lua
+++ b/SmartBuff.lua
@@ -6,10 +6,10 @@
 -- Cast the most important buffs on you, tanks or party/raid members/pets.
 -------------------------------------------------------------------------------
 
-SMARTBUFF_DATE          = "240123";
+SMARTBUFF_DATE          = "030223";
 
 SMARTBUFF_VERSION       = "r18."..SMARTBUFF_DATE;
-SMARTBUFF_VERSIONNR     = 100002;
+SMARTBUFF_VERSIONNR     = 100003;
 SMARTBUFF_TITLE         = "SmartBuff";
 SMARTBUFF_SUBTITLE      = "Supports you in casting buffs";
 SMARTBUFF_DESC          = "Cast the most important buffs on you, your tanks, party/raid members/pets";
@@ -924,32 +924,17 @@ end
 
 -- Get Spell ID from spellbook
 function SMARTBUFF_GetSpellID(spellname)
+  local i, id = 1, nil;
+  local spellN, spellId, skillType;
   if (spellname) then
     spellname = string.lower(spellname);
   else
     return nil;
   end
-
-  local i = 0;
-  local nSpells = 0;
-  local id = nil;
-  local spellN, spellId, skillType;
-
-  -- Get number of spells
-  --for i = 1, GetNumSpellTabs() do
-  -- Common and specialization
-  for i = 1, GetNumSpellTabs() do
-    local _, _, _, n = GetSpellTabInfo(i);
-    nSpells = nSpells + n;
-  end
-
-  i = 0;
-  while (i < nSpells) do
-    i = i + 1;
+  while GetSpellBookItemName(i, BOOKTYPE_SPELL) do
     spellN = GetSpellBookItemName(i, BOOKTYPE_SPELL);
     skillType, spellId = GetSpellBookItemInfo(i, BOOKTYPE_SPELL);
     --print(spellN.." "..spellId);
-
     if (skillType == "FLYOUT") then
       for j = 1, GetNumFlyouts() do
         local fid = GetFlyoutID(j);
@@ -965,20 +950,18 @@ function SMARTBUFF_GetSpellID(spellname)
 		    end
 		  end
     end
-
     if (spellN ~= nil and string.lower(spellN) == spellname) then
       id = spellId;
       break;
     end
+    i = i + 1;
   end
-
   if (id) then
     if (IsPassiveSpell(id) or skillType == "FUTURESPELL" or not IsSpellKnown(id)) then
       id = nil;
       i = nil;
     end
   end
-
   return id, i;
 end
 -- END SMARTBUFF_GetSpellID

--- a/SmartBuff.toc
+++ b/SmartBuff.toc
@@ -1,6 +1,6 @@
-## Interface: 100002
+## Interface: 100005
 ## Title: SmartBuff |cffffffff(Retail)|r by |cff00ff00Codermik & Aeldra|r
-## Version: 18.100002
+## Version: 18.100003
 ## Author: |cff20d2ffCodermik & Aeldra|r (EU-Proudmoore)
 ## Contributing Author: |cff20d2ffSpeedwaystar
 ## Notes: Cast the most important buffs on you or party/raid members/pets. Use /sbm for options menu.


### PR DESCRIPTION
...instead of GetNumSpellTabs, since the latter does not reliably return all known spells.
fixes:https://github.com/Softrix/SmartBuff-Retail/issues/9
credit: Mokay https://discord.com/channels/697774223833170000/864095814950977557/1066432962582806548
Signed-off-by: speedwaystar <speedwaystar@gmail.com>