### PR TITLE
horric visions template, itemID fixes and missing weapon types

### DIFF
--- a/SmartBuff.buffs.lua
+++ b/SmartBuff.buffs.lua
@@ -152,15 +152,15 @@ function SMARTBUFF_InitItemList()
   _,SMARTBUFF_TWWWeaponEnhance3_q1  = C_Item.GetItemInfo(222508);   --  Ironclaw Whetstone
   _,SMARTBUFF_TWWWeaponEnhance3_q2  = C_Item.GetItemInfo(222509);   --  Ironclaw Whetstone
   _,SMARTBUFF_TWWWeaponEnhance3_q3  = C_Item.GetItemInfo(222510);   --  Ironclaw Whetstone
-  _,SMARTBUFF_TWWWeaponEnhance4_q1  = C_Item.GetItemInfo(224105);   --  Oil of Beledar's Grace
-  _,SMARTBUFF_TWWWeaponEnhance4_q2  = C_Item.GetItemInfo(224106);   --  Oil of Beledar's Grace
-  _,SMARTBUFF_TWWWeaponEnhance4_q3  = C_Item.GetItemInfo(224107);   --  Oil of Beledar's Grace
-  _,SMARTBUFF_TWWWeaponEnhance5_q1  = C_Item.GetItemInfo(224108);   --  Oil of Deep Toxins
-  _,SMARTBUFF_TWWWeaponEnhance5_q2  = C_Item.GetItemInfo(224109);   --  Oil of Deep Toxins
-  _,SMARTBUFF_TWWWeaponEnhance5_q3  = C_Item.GetItemInfo(224109);   --  Oil of Deep Toxins
-  _,SMARTBUFF_TWWWeaponEnhance6_q1  = C_Item.GetItemInfo(224110);   --  Algari Mana Oil
-  _,SMARTBUFF_TWWWeaponEnhance6_q2  = C_Item.GetItemInfo(224111);   --  Algari Mana Oil
-  _,SMARTBUFF_TWWWeaponEnhance6_q3  = C_Item.GetItemInfo(224113);   --  Algari Mana Oil
+  _,SMARTBUFF_TWWWeaponEnhance4_q1  = C_Item.GetItemInfo(224108);   --  Oil of Beledar's Grace
+  _,SMARTBUFF_TWWWeaponEnhance4_q2  = C_Item.GetItemInfo(224109);   --  Oil of Beledar's Grace
+  _,SMARTBUFF_TWWWeaponEnhance4_q3  = C_Item.GetItemInfo(224110);   --  Oil of Beledar's Grace
+  _,SMARTBUFF_TWWWeaponEnhance5_q1  = C_Item.GetItemInfo(224111);   --  Oil of Deep Toxins
+  _,SMARTBUFF_TWWWeaponEnhance5_q2  = C_Item.GetItemInfo(224112);   --  Oil of Deep Toxins
+  _,SMARTBUFF_TWWWeaponEnhance5_q3  = C_Item.GetItemInfo(224113);   --  Oil of Deep Toxins
+  _,SMARTBUFF_TWWWeaponEnhance6_q1  = C_Item.GetItemInfo(224105);   --  Algari Mana Oil
+  _,SMARTBUFF_TWWWeaponEnhance6_q2  = C_Item.GetItemInfo(224106);   --  Algari Mana Oil
+  _,SMARTBUFF_TWWWeaponEnhance6_q3  = C_Item.GetItemInfo(224107);   --  Algari Mana Oil
 
 
   -- Food

--- a/SmartBuff.lua
+++ b/SmartBuff.lua
@@ -709,11 +709,7 @@ function SMARTBUFF_OnEvent(self, event, ...)
     end
   end
 
-  -- This is a blizzard bug workaround that spams GROUP_ROSTER_UPDATE during delves
-  --local name, instanceType, difficultyID, difficultyName, maxPlayers, dynamicDifficulty, isDynamic, instanceID, instanceGroupSize, LfgDungeonID = GetInstanceInfo()
-  -- if event == "ZONE_CHANGED_NEW_AREA" or (event == "GROUP_ROSTER_UPDATE" and instanceType ~= "scenario") or event == "PLAYER_LEVEL_UP" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "ACTIVE_DELVE_DATA_UPDATE" then 
-  -- TODO disabled the above bug workaround since it prevents Delve detection from working 
-  if event == "ZONE_CHANGED_NEW_AREA" or event == "GROUP_ROSTER_UPDATE" or event == "PLAYER_LEVEL_UP" or event == "PLAYER_SPECIALIZATION_CHANGED" or event == "ACTIVE_DELVE_DATA_UPDATE" then 
+  if event == "ZONE_CHANGED_NEW_AREA" or event == "GROUP_ROSTER_UPDATE" or event == "PLAYER_LEVEL_UP" or event == "PLAYER_SPECIALIZATION_CHANGED" then
       SMARTBUFF_SetTemplate()
   end
 end
@@ -798,15 +794,16 @@ Enum.SmartBuffGroup = {
   LFR = 3,
   Raid = 4,
   MythicKeystone = 5,
-  Delve = 6,
-  Battleground = 7,
-  Arena = 8,
-  VoTI = 9,
-  Custom1 = 10,
-  Custom2 = 11,
-  Custom3 = 12,
-  Custom4 = 13,
-  Custom5 = 14
+  HorrificVision = 6,
+  Delve = 7,
+  Battleground = 8,
+  Arena = 9,
+  VoTI = 10,
+  Custom1 = 11,
+  Custom2 = 12,
+  Custom3 = 13,
+  Custom4 = 14,
+  Custom5 = 15
 }
 
 -- Set the current template and create an array of units
@@ -821,6 +818,7 @@ function SMARTBUFF_SetTemplate(force)
   if O.AutoSwitchTemplate then
     newTemplate = SMARTBUFF_TEMPLATES[Enum.SmartBuffGroup.Solo];
     local name, instanceType, difficultyID, difficultyName, maxPlayers, dynamicDifficulty, isDynamic, instanceID, instanceGroupSize, LfgDungeonID = GetInstanceInfo()
+    --printd("name: " .. name, ", instanceType: " .. instanceType .. ", difficultyID: " .. difficultyID .. ", difficultyName: " .. difficultyName, ", instanceID: " .. instanceID)
 
     if IsInRaid() then
       newTemplate = SMARTBUFF_TEMPLATES[Enum.SmartBuffGroup.Raid];
@@ -839,7 +837,9 @@ function SMARTBUFF_SetTemplate(force)
         newTemplate = SMARTBUFF_TEMPLATES[Enum.SmartBuffGroup.MythicKeystone];
       end
     end
-    if (difficultyID == 208) then
+    if (difficultyID == 152) then
+      newTemplate = SMARTBUFF_TEMPLATES[Enum.SmartBuffGroup.HorrificVision];
+    elseif (difficultyID == 208) then
       newTemplate = SMARTBUFF_TEMPLATES[Enum.SmartBuffGroup.Delve];
     end
   end

--- a/localization.en.lua
+++ b/localization.en.lua
@@ -26,10 +26,10 @@ SMARTBUFF_CREDITS = "|cffffffff"
 ;
 
 -- Weapon types
-SMARTBUFF_WEAPON_STANDARD = {"Daggers", "Axes", "Swords", "Maces", "Staves", "Fist Weapons", "Polearms", "Thrown", "Crossbows", "Bows", "Shields"};
+SMARTBUFF_WEAPON_STANDARD = {"Daggers", "Axes", "Swords", "Maces", "Staves", "Fist Weapons", "Polearms", "Thrown", "Crossbows", "Bows", "Shields", "Guns", "Warglaives"};
 SMARTBUFF_WEAPON_BLUNT = {"Maces", "Staves", "Fist Weapons"};
 SMARTBUFF_WEAPON_BLUNT_PATTERN = "Weightstone$";
-SMARTBUFF_WEAPON_SHARP = {"Daggers", "Axes", "Swords", "Polearms"};
+SMARTBUFF_WEAPON_SHARP = {"Daggers", "Axes", "Swords", "Polearms", "Warglaives"};
 SMARTBUFF_WEAPON_SHARP_PATTERN = "Sharpening Stone$";
 
 -- Creature types
@@ -44,7 +44,7 @@ SMARTBUFF_UNDEAD    = "Undead";
 SMARTBUFF_CLASSES = {"Druid", "Hunter", "Mage", "Paladin", "Priest", "Rogue", "Shaman", "Warlock", "Warrior", "Death Knight", "Monk", "Demon Hunter", "Evoker", "Hunter Pet", "Warlock Pet", "Death Knight Pet", "Tank", "Healer", "Damage Dealer"};
 
 -- Templates and Instances
-SMARTBUFF_TEMPLATES = {"Solo", "Party", "LFR", "Raid", "Mythic Keystone", "Delve", "Battleground", "Arena", "Vault of the Incarnates", "Aberrus, The Shadowed Crucible", "Amirdrassil, the Dream's Hope", "Nerub-ar Palace", "Liberation of Undermine", "Custom 1", "Custom 2", "Custom 3", "Custom 4", "Custom 5"};
+SMARTBUFF_TEMPLATES = {"Solo", "Party", "LFR", "Raid", "Mythic Keystone", "Horrific Vision", "Delve", "Battleground", "Arena", "Vault of the Incarnates", "Aberrus, The Shadowed Crucible", "Amirdrassil, the Dream's Hope", "Nerub-ar Palace", "Liberation of Undermine", "Custom 1", "Custom 2", "Custom 3", "Custom 4", "Custom 5"};
 SMARTBUFF_INSTANCES = {"Vault of the Incarnates", "Aberrus, the Shadowed Crucible", "Amirdrassil, the Dream's Hope", "Nerub-ar Palace", "Liberation of Undermine"};
 
 -- Mount


### PR DESCRIPTION
* ADDED: horrific visions template
* FIXED: incorrect itemIDs for Oil of Beledar's Grace, Oil of Deep Toxins and Algari Mana Oil
* ADDED: guns and warglaives to SMARTBUFF_WEAPON_STANDARD
* ADDED: warglaives to SMARTBUFF_WEAPON_SHARP